### PR TITLE
Merging test case for non-separable constraint in GLMM

### DIFF
--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -190,7 +190,7 @@ def plotResults(traj, label, boundary=None):
 
 if __name__ == "__main__":
     xy = np.array([-1.,-1.])
-    boundary = "line" # "circle" 
+    boundary = "circle" # "line"
     max_iter = 100
 
     # step sizes and proximal operators for boundary


### PR DESCRIPTION
GLMM allows solution for f(X1,X2...) with constrain g(X1), h(X2) etc. This test case demonstrates that it *cannot* solve a case where the constraint is of the form g(X1,X2), i.e. it cannot be separated.