### PR TITLE
Nesterov admm

### DIFF
--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     max_iter = 100
 
     # step sizes and proximal operators for boundary
-    step_f = steps_f12()
+    step_f = 0.01#steps_f12()
     prox_g = partial(prox_lim, boundary=boundary)
     prox_gradf_ = partial(prox_gradf_lim, boundary=boundary)
 
@@ -232,5 +232,5 @@ if __name__ == "__main__":
         x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=True)
         plotResults(tr, "GLMM direct", boundary=boundary)
 
-        x, tr = pa.glmm(XY, prox_gradf12_, steps_f12, prox_g_direct, accelerated=True, max_iter=max_iter, traceback=True)
+        x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, accelerated=True, max_iter=max_iter, traceback=True)
         plotResults(tr, "GLMM direct accelerated", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -126,10 +126,7 @@ def prox_gradf_lim12(x, step, j=None, Xs=None, boundary=None):
 def steps_f12(j=None, Xs=None):
     """Stepsize for f update given current state of Xs"""
     # Lipschitz const is always 2
-    if j==0:
-        L = 2
-    else:
-        L = 2
+    L = 2
     slack = 1.
     return slack / L
 
@@ -186,26 +183,36 @@ if __name__ == "__main__":
     prox_g = partial(prox_lim, boundary=boundary)
     prox_gradf_ = partial(prox_gradf_lim, boundary=boundary)
 
+    """
     # PGM without boundary
     x, tr = pa.pgm(xy, prox_gradf, step_f, max_iter=max_iter, relax=1, traceback=True)
     plotResults(tr, "PGM no boundary")
+    """
 
     # PGM
-    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, relax=1, traceback=True)
+    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=False, traceback=True)
     plotResults(tr, "PGM", boundary=boundary)
 
     # APGM
-    x, tr = pa.apgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
+    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
     plotResults(tr, "APGM", boundary=boundary)
 
     # ADMM
-    x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, traceback=True)
+    x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, accelerated=False, traceback=True)
     plotResults(tr, "ADMM", boundary=boundary)
+
+    # ADMM with acceleration
+    x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, traceback=True)
+    plotResults(tr, "ADMM accelerated", boundary=boundary)
 
     # ADMM with direct constraint projection
     prox_g_direct = None
-    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
+    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, accelerated=False, traceback=True)
     plotResults(tr, "ADMM direct", boundary=boundary)
+
+    # and with acceleration
+    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
+    plotResults(tr, "ADMM direct accelerated", boundary=boundary)
 
     # SDMM
     M = 2

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -190,39 +190,31 @@ if __name__ == "__main__":
     """
 
     # PGM
-    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=False, traceback=True)
+    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
     plotResults(tr, "PGM", boundary=boundary)
 
     # APGM
-    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
+    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=True, traceback=True)
     plotResults(tr, "PGM accelerated", boundary=boundary)
 
     # ADMM
-    x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, accelerated=False, traceback=True)
-    plotResults(tr, "ADMM", boundary=boundary)
-
-    # ADMM with acceleration
     x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, traceback=True)
-    plotResults(tr, "ADMM accelerated", boundary=boundary)
+    plotResults(tr, "ADMM", boundary=boundary)
 
     # ADMM with direct constraint projection
     prox_g_direct = None
-    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, accelerated=False, traceback=True)
+    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
     plotResults(tr, "ADMM direct", boundary=boundary)
 
     # and with acceleration
-    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
+    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, accelerated=True, traceback=True)
     plotResults(tr, "ADMM direct accelerated", boundary=boundary)
 
     # SDMM
     M = 2
     proxs_g = [prox_g] * M # using same constraint several, i.e. M, times
-    x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, accelerated=False, max_iter=max_iter, traceback=True)
-    plotResults(tr, "SDMM", boundary=boundary)
-
-    # and with acceleration
     x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, max_iter=max_iter, traceback=True)
-    plotResults(tr, "SDMM accelerated", boundary=boundary)
+    plotResults(tr, "SDMM", boundary=boundary)
 
     # GLMM
     XY = [np.array([xy[0]]), np.array([xy[1]])]
@@ -239,3 +231,6 @@ if __name__ == "__main__":
         prox_g_direct = None
         x, tr = pa.glmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=True)
         plotResults(tr, "GLMM direct", boundary=boundary)
+
+        x, tr = pa.glmm(XY, prox_gradf12_, steps_f12, prox_g_direct, accelerated=True, max_iter=max_iter, traceback=True)
+        plotResults(tr, "GLMM direct accelerated", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
     # APGM
     x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
-    plotResults(tr, "APGM", boundary=boundary)
+    plotResults(tr, "PGM accelerated", boundary=boundary)
 
     # ADMM
     x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, accelerated=False, traceback=True)
@@ -217,8 +217,12 @@ if __name__ == "__main__":
     # SDMM
     M = 2
     proxs_g = [prox_g] * M # using same constraint several, i.e. M, times
-    x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, max_iter=max_iter, traceback=True)
+    x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, accelerated=False, max_iter=max_iter, traceback=True)
     plotResults(tr, "SDMM", boundary=boundary)
+
+    # and with acceleration
+    x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, max_iter=max_iter, traceback=True)
+    plotResults(tr, "SDMM accelerated", boundary=boundary)
 
     # GLMM
     XY = [np.array([xy[0]]), np.array([xy[1]])]

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     max_iter = 100
 
     # step sizes and proximal operators for boundary
-    step_f = 0.01#steps_f12()
+    step_f = steps_f12()
     prox_g = partial(prox_lim, boundary=boundary)
     prox_gradf_ = partial(prox_gradf_lim, boundary=boundary)
 

--- a/proxmin/nmf.py
+++ b/proxmin/nmf.py
@@ -34,7 +34,7 @@ def prox_likelihood(X, step, Xs=None, j=None, Y=None, W=None,
         return prox_likelihood_S(X, step, A=Xs[0], Y=Y, prox_g=prox_S, W=W)
 
 class Steps_AS:
-    def __init__(self, slack=0.5, Wmax=1):
+    def __init__(self, slack=0.9, Wmax=1):
         """Helper class to compute the Lipschitz constants of grad f.
 
         Because the spectral norm is expensive to compute, it will only update
@@ -78,14 +78,14 @@ class Steps_AS:
         return self.slack / self.stored[j]
 
 def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plus,
-        proxs_g=None, steps_g=None, Ls=None, update_order=None, steps_g_update='steps_f', max_iter=1000, e_rel=1e-3, traceback=False):
+        proxs_g=None, steps_g=None, Ls=None, update_order=None, accelerated=False, steps_g_update='steps_f', slack=1, max_iter=1000, e_rel=1e-3, traceback=False):
 
     # create stepsize callback, needs max of W
     if W is not None:
         Wmax = W.max()
     else:
         W = Wmax = 1
-    steps_f = Steps_AS(Wmax=Wmax)
+    steps_f = Steps_AS(Wmax=Wmax, slack=slack)
 
     # gradient step, followed by direct application of prox_S or prox_A
     from functools import partial
@@ -93,7 +93,7 @@ def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plu
 
     Xs = [A0, S0]
     res = algorithms.glmm(Xs, f, steps_f, proxs_g, steps_g=steps_g, Ls=Ls,
-                          update_order=update_order, steps_g_update=steps_g_update, max_iter=max_iter, e_rel=e_rel, traceback=traceback)
+                          update_order=update_order, steps_g_update=steps_g_update, accelerated=accelerated, max_iter=max_iter, e_rel=e_rel, traceback=traceback)
 
     if not traceback:
         return res[0], res[1]

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -141,6 +141,7 @@ class Traceback(object):
                     self.history[j][k] = [[]]
                 else:
                     self.history[j][k] = [[] for m in range(M)]
+        """
         # Check that the variables have been updated once per iteration
         elif np.any([[len(h)!=it+self.offset for h in self.history[j][k]] for k in kwargs.keys()]):
             for k in kwargs.keys():
@@ -148,7 +149,7 @@ class Traceback(object):
                     if len(h) != it+self.offset:
                         err_str = "At iteration {0}, {1}[{2}] already has {3} entries"
                         raise Exception(err_str.format(it, k, n, len(h)-self.offset))
-
+        """
         # Add the variables to the history
         for k,v in kwargs.items():
             if M is None or M == 0:


### PR DESCRIPTION
This PR provide Nesterov acceleration for PGM, and ADMM-derivates if they don't use a prox_g, i.e. if all proximal operations are equivalent to forward-backward.

The reason this does not work with prox_g is that the acceleration only applies to X, but there is no clear way to accelerate Z and U, or even if they should be accelerated.

Nonetheless, for the NMF we often only put projection-style constraints on each variables, and in this case acceleration is useful.