### PR TITLE
Remove zeros_like

### DIFF
--- a/proxmin/algorithms.py
+++ b/proxmin/algorithms.py
@@ -135,8 +135,8 @@ def admm(X0, prox_f, step_f, prox_g=None, step_g=None, L=None, accelerated=False
 
     if traceback:
         tr = utils.Traceback()
-        tr.update_history(it, X=X, step_f=step_f, Z=Z, U=U, R=np.zeros_like(Z),
-                          S=np.zeros_like(X), step_g=step_g)
+        tr.update_history(it, X=X, step_f=step_f, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
+                          S=np.zeros(X.shape, dtype=X.dtype), step_g=step_g)
         if accelerated:
             tr.update_history(it, omega=prox_f_.omega)
 
@@ -175,8 +175,8 @@ def admm(X0, prox_f, step_f, prox_g=None, step_g=None, L=None, accelerated=False
                         prox_f_.t = 1.
                         prox_f_.omega = 0.
                     logger.info("Restarting with step_f = %.3f" % step_f)
-                    tr.update_history(it, X=X, Z=Z, U=U, R=np.zeros_like(Z), S=np.zeros_like(X),
-                                      step_f=step_f, step_g=step_g)
+                    tr.update_history(it, X=X, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
+                                      S=np.zeros(X.shape, dtype=X.dtype), step_f=step_f, step_g=step_g)
                     if accelerated:
                         tr.update_history(it, omega=prox_f_.omega)
 
@@ -261,8 +261,8 @@ def sdmm(X0, prox_f, step_f, proxs_g=None, steps_g=None, Ls=None, e_rel=1e-6, e_
     if traceback:
         tr = utils.Traceback()
         tr.update_history(it, X=X, step_f=step_f, omega=omega)
-        tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros_like(Z),
-                          S=[np.zeros_like(X) for n in range(M)], steps_g=steps_g)
+        tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
+                          S=[np.zeros(X.shape, dtype=X.dtype) for n in range(M)], steps_g=steps_g)
 
     while it < max_iter:
 
@@ -295,8 +295,8 @@ def sdmm(X0, prox_f, step_f, proxs_g=None, steps_g=None, Ls=None, e_rel=1e-6, e_
 
                 X,Z,U  = utils.initXZU(X0, _L)
                 tr.update_history(it, X=X, step_f=step_f)
-                tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros_like(Z),
-                                  S=[np.zeros_like(X) for n in range(M)], steps_g=steps_g)
+                tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
+                                  S=[np.zeros(X.shape, dtype=X.dtype) for n in range(M)], steps_g=steps_g)
                 logger.info("Restarting with step_f = %.3f" % step_f)
 
         Rk = R
@@ -464,12 +464,13 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, acceler
         tr = utils.Traceback(N)
         for j in update_order:
             if M[j]>0:
-                _S = [np.zeros_like(X[j]) for n in range(M[j])]
+                _S = [np.zeros(X[j].shape, dtype=X[j].dtype) for n in range(M[j])]
             else:
-                _S = np.zeros_like(X[j])
+                _S = np.zeros(X[j].shape, dtype=X[j].dtype)
             tr.update_history(it, j=j, X=X[j], steps_f=steps_f[j])
-            tr.update_history(it, j=j, M=M[j], steps_g=steps_g_[j], Z=Z[j], U=U[j], R=np.zeros_like(Z[j]),
-                              S=[np.zeros_like(X[j]) for n in range(M[j])])
+            tr.update_history(it, j=j, M=M[j], steps_g=steps_g_[j], Z=Z[j], U=U[j],
+                              R=np.zeros(Z[j].shape, dtype=Z[j].dtype),
+                              S=[np.zeros(X[j].shape, dtype=X[j].dtype) for n in range(M[j])])
             if accelerated:
                 tr.update_history(it, j=j, omega=proxs_f_acc[j].omega)
 

--- a/proxmin/nmf.py
+++ b/proxmin/nmf.py
@@ -55,11 +55,11 @@ class Steps_AS:
         if WA is 1:
             self.WA = WA
         else:
-            self.WA = scipy.sparse.diags(WA.flatten())
+            self.WA = scipy.sparse.diags(WA.reshape(-1))
         if WS is 1:
             self.WS = WS
         else:
-            self.WS = scipy.sparse.diags(WS.flatten())
+            self.WS = scipy.sparse.diags(WS.reshape(-1))
 
         # two independent caches for Lipschitz constants
         self._cb = [utils.ApproximateCache(self._one_over_lipschitzA, slack=slack, max_stride=max_stride),

--- a/proxmin/operators.py
+++ b/proxmin/operators.py
@@ -22,7 +22,7 @@ def prox_id(X, step):
 def prox_zero(X, step):
     """Proximal operator to project onto zero
     """
-    return np.zeros_like(X)
+    return np.zeros(X.shape, dtype=X.dtype)
 
 def prox_plus(X, step):
     """Projection onto non-negative numbers
@@ -200,10 +200,10 @@ def get_gradient_x(shape, px):
     c = -np.ones((width,))
     c[px] = 0
     # Set the pixels leading up to the peak from the left
-    r = np.zeros_like(c)
+    r = np.zeros(c.shape, dtype=c.dtype)
     r[:px] = 1
     # Set the pixels leading up to the peak from the right
-    l = np.zeros_like(c)
+    l = np.zeros(c.shape, dtype=c.dtype)
     l[px:] = 1
     # Make a block for a single row in the image
     block = scipy.sparse.diags([l, c, r], [-1, 0,1], shape=(width,width))

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -7,7 +7,7 @@ def get_spectral_norm(L):
     if L is None:
         return 1
     elif hasattr(L, "spectral_norm"):
-        return L.spectral_norm()
+        return L.spectral_norm
     else: # linearized ADMM
         LTL = L.T.dot(L)
         # need spectral norm of L

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -63,7 +63,7 @@ class MatrixAdapter(object):
         # axis=0 is not needed because it can be done with a normal matrix
         # dot product
         if self.axis == 1:
-            return self.L.dot(X.flatten()).reshape(X.shape[0], -1)
+            return self.L.dot(X.reshape(-1)).reshape(X.shape[0], -1)
         raise NotImplementedError("MatrixAdapter.dot() is not useful with axis=0.\n"
                                   "Use regular matrix dot product instead!")
 

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 def get_spectral_norm(L):
     if L is None:
         return 1
+    elif hasattr(L, "spectral_norm"):
+        return L.spectral_norm()
     else: # linearized ADMM
         LTL = L.T.dot(L)
         # need spectral norm of L
@@ -259,13 +261,13 @@ def initXZU(X0, L):
     X = X0.copy()
     if not isinstance(L, list):
         Z = L.dot(X).copy()
-        U = np.zeros_like(Z)
+        U = np.zeros(Z.shape, dtype=Z.dtype)
     else:
         Z = []
         U = []
         for i in range(len(L)):
             Z.append(L[i].dot(X).copy())
-            U.append(np.zeros_like(Z[i]))
+            U.append(np.zeros(Z[i].shape, dtype=Z[i].dtype))
     return X,Z,U
 
 def l2sq(x):
@@ -332,7 +334,7 @@ def update_variables(X, Z, U, prox_f, step_f, prox_g, step_g, L):
             X[:] = prox_f(X, step_f)
             LX = X
             Z[:] = X[:]
-            R = np.zeros_like(X)
+            R = np.zeros(X.shape, dtype=X.dtype)
             S += X
 
     else:


### PR DESCRIPTION
The numpy zeros_like function has an extra internal copy to allow
initializing a character array to a string of zeros. This extra
behavior can be costly, for example in scarlet 10% of the processing
time was saved by switching from `np.zeros_like(X)` to
`np.zeros(X.shape dtype=X.dtype)`.

Also, this adds a test for the function/property `spectral_norm` in `MatrixAdapter`, which we need for scarlet.