### PR TITLE
Block PGM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ The methods in this package provide solvers for constrained optimization problem
 
 The algorithms:
 
-* Proximal Gradient Method (PGM): *forward-backward* split with a single smooth function with a Lipschitz-continuous gradient and a single (non-smooth) constraint function. Nesterov acceleration is available.
-* Alternating Direction Method of Multipliers (ADMM): Rachford-Douglas split for two potentially non-smooth functions. We use the linearized form of it solve for additional linear mappings in the constraint functions.
-* Simultaneous Direction Method of Multipliers (SDMM): Extension of linearized ADMM for several constraint functions.
-* Block-Simultaneous Direction Method of Multipliers (bSDMM): Extension of SDMM to work with objective functions that are convex in several arguments. It's a proximal version of Block coordinate descent methods.
+* **Proximal Gradient Method (PGM)**: *forward-backward* split with a single smooth function with a Lipschitz-continuous gradient and a single (non-smooth) constraint function. Nesterov acceleration is available.
+* **Block/Alternating Proximal Gradient Method (bPGM)**: Extension of PGM to objective functions that are convex in several arguments; optional Nesterov acceleration.
+* **Alternating Direction Method of Multipliers (ADMM)**: Rachford-Douglas split for two potentially non-smooth functions. We use the linearized form of it solve for additional linear mappings in the constraint functions.
+* **Simultaneous Direction Method of Multipliers (SDMM)**: Extension of linearized ADMM for several constraint functions.
+* **Block-Simultaneous Direction Method of Multipliers (bSDMM)**: Extension of SDMM to work with objective functions that are convex in several arguments. It's a proximal version of Block coordinate descent methods.
 
-In addition, bSDMM is used as the backend of a solver for Non-negative Matrix Factorization (NMF). It allows the employment of an arbitrary number of constraints on each of the matrix factors.
+In addition, bSDMM is used as the backend of a solver for Non-negative Matrix Factorization (NMF). As our algorithm allows an arbitrary number of constraints on each of the matrix factors, we prefer the term Constrained Matrix Factorization.
 
 Details can be found in the [paper](http://arxiv.org/abs/1708.09066) *"Block-Simultaneous Direction Method of Multipliers — A proximal primal-dual splitting algorithm for nonconvex problems with multiple constraints"* by Fred Moolekamp and Peter Melchior.
 
@@ -110,7 +111,7 @@ X = pa.admm(X, prox_gradf, step_f, prox_circle, e_rel=1e-3, e_abs=1e-3)
 
 A fully working example to demonstrate the principle of operations is [examples/parabola.py] that find the minimum of a 2D parabola under hard boundary constraints (on a shifted circle or the intersection of lines).
 
-## Non-negative matrix factorization (NMF)
+## Constrained matrix factorization (CMF)
 
 We have developed this package with a few application cases in mind. One is matrix factorization under constraints on the matrix factors, i.e. describing a target matrix **Y** as a product of **A S**. If those constraints are only non-negativity, the method is known as NMF.
 

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -1,6 +1,7 @@
 import sys, numpy as np
 from functools import partial
 from proxmin import algorithms as pa
+from proxmin.utils import Traceback
 
 # location of true minimum of f
 dx,dy = 1,0.5
@@ -185,30 +186,36 @@ if __name__ == "__main__":
     prox_gradf_ = partial(prox_gradf_lim, boundary=boundary)
 
     # PGM without boundary
-    x, tr = pa.pgm(xy, prox_gradf, step_f, max_iter=max_iter, relax=1, traceback=True)
+    tr = Traceback()
+    x = pa.pgm(xy, prox_gradf, step_f, max_iter=max_iter, relax=1, traceback=tr)
     plotResults(tr, "PGM no boundary")
 
     # PGM
-    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=True)
+    tr = Traceback()
+    x = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, traceback=tr)
     plotResults(tr, "PGM", boundary=boundary)
 
     # APGM
-    x, tr = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=True, traceback=True)
+    tr = Traceback()
+    x = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=True, traceback=tr)
     plotResults(tr, "PGM accelerated", boundary=boundary)
 
     # ADMM
-    x, tr = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, traceback=True)
+    tr = Traceback()
+    x  = pa.admm(xy, prox_gradf, step_f, prox_g, max_iter=max_iter, traceback=tr)
     plotResults(tr, "ADMM", boundary=boundary)
 
     # ADMM with direct constraint projection
     prox_g_direct = None
-    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
+    tr = Traceback()
+    x = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=tr)
     plotResults(tr, "ADMM direct", boundary=boundary)
 
     # SDMM
     M = 2
     proxs_g = [prox_g] * M # using same constraint several, i.e. M, times
-    x, tr = pa.sdmm(xy, prox_gradf, step_f, proxs_g, max_iter=max_iter, traceback=True)
+    tr = Traceback()
+    x = pa.sdmm(xy, prox_gradf, step_f, proxs_g, max_iter=max_iter, traceback=tr)
     plotResults(tr, "SDMM", boundary=boundary)
 
     # Block-SDMM
@@ -218,15 +225,18 @@ if __name__ == "__main__":
         M1 = 7
         M2 = 2
         proxs_g = [[prox_xline]*M1, [prox_yline]*M2]
-        x, tr = pa.bsdmm(XY, prox_gradf12, steps_f12, proxs_g, max_iter=max_iter, traceback=True)
+        tr = Traceback(N)
+        x = pa.bsdmm(XY, prox_gradf12, steps_f12, proxs_g, max_iter=max_iter, traceback=tr)
         plotResults(tr, "GLMM", boundary=boundary)
 
         # GLMM with direct constraint projection
         prox_gradf12_ = partial(prox_gradf_lim12, boundary=boundary)
         prox_g_direct = None
-        x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=True)
+        tr = Traceback(N)
+        x = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=tr)
         plotResults(tr, "GLMM direct", boundary=boundary)
 
         # BPGM
-        x, tr = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, accelerated=True, traceback=True)
+        tr = Traceback(N)
+        x = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, accelerated=True, traceback=tr)
         plotResults(tr, "BPGM direct", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -228,5 +228,5 @@ if __name__ == "__main__":
         plotResults(tr, "GLMM direct", boundary=boundary)
 
         # BPGM
-        x, tr = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, traceback=True)
+        x, tr = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, accelerated=True, traceback=True)
         plotResults(tr, "BPGM direct", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -227,16 +227,16 @@ if __name__ == "__main__":
         proxs_g = [[prox_xline]*M1, [prox_yline]*M2]
         tr = Traceback(N)
         x = pa.bsdmm(XY, prox_gradf12, steps_f12, proxs_g, max_iter=max_iter, traceback=tr)
-        plotResults(tr, "GLMM", boundary=boundary)
+        plotResults(tr, "bSDMM", boundary=boundary)
 
-        # GLMM with direct constraint projection
+        # bSDMM with direct constraint projection
         prox_gradf12_ = partial(prox_gradf_lim12, boundary=boundary)
         prox_g_direct = None
         tr = Traceback(N)
         x = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=tr)
-        plotResults(tr, "GLMM direct", boundary=boundary)
+        plotResults(tr, "bSDMM direct", boundary=boundary)
 
         # BPGM
         tr = Traceback(N)
         x = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, accelerated=True, traceback=tr)
-        plotResults(tr, "BPGM direct", boundary=boundary)
+        plotResults(tr, "bPGM", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -127,7 +127,7 @@ def steps_f12(j=None, Xs=None):
     """Stepsize for f update given current state of Xs"""
     # Lipschitz const is always 2
     L = 2
-    slack = 1.
+    slack = 0.1# 1.
     return slack / L
 
 
@@ -180,6 +180,7 @@ if __name__ == "__main__":
 
     # step sizes and proximal operators for boundary
     step_f = steps_f12()
+
     prox_g = partial(prox_lim, boundary=boundary)
     prox_gradf_ = partial(prox_gradf_lim, boundary=boundary)
 
@@ -225,3 +226,7 @@ if __name__ == "__main__":
         prox_g_direct = None
         x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=True)
         plotResults(tr, "GLMM direct", boundary=boundary)
+
+        # BPGM
+        x, tr = pa.bpgm(XY, prox_gradf12_, steps_f12, max_iter=max_iter, traceback=True)
+        plotResults(tr, "BPGM direct", boundary=boundary)

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
 
     # APGM
     tr = Traceback()
-    x = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=True, traceback=tr)
+    x = pa.pgm(xy, prox_gradf_, step_f, max_iter=max_iter, accelerated=True,  traceback=tr)
     plotResults(tr, "PGM accelerated", boundary=boundary)
 
     # ADMM

--- a/examples/parabola.py
+++ b/examples/parabola.py
@@ -204,10 +204,6 @@ if __name__ == "__main__":
     x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, traceback=True)
     plotResults(tr, "ADMM direct", boundary=boundary)
 
-    # and with acceleration
-    x, tr = pa.admm(xy, prox_gradf_, step_f, prox_g_direct, max_iter=max_iter, accelerated=True, traceback=True)
-    plotResults(tr, "ADMM direct accelerated", boundary=boundary)
-
     # SDMM
     M = 2
     proxs_g = [prox_g] * M # using same constraint several, i.e. M, times
@@ -229,6 +225,3 @@ if __name__ == "__main__":
         prox_g_direct = None
         x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, max_iter=max_iter, traceback=True)
         plotResults(tr, "GLMM direct", boundary=boundary)
-
-        x, tr = pa.bsdmm(XY, prox_gradf12_, steps_f12, prox_g_direct, accelerated=True, max_iter=max_iter, traceback=True)
-        plotResults(tr, "GLMM direct accelerated", boundary=boundary)

--- a/examples/unmixing.py
+++ b/examples/unmixing.py
@@ -1,4 +1,5 @@
 from proxmin import nmf
+from proxmin.utils import Traceback
 from scipy.optimize import linear_sum_assignment
 import numpy as np
 import matplotlib.pyplot as plt
@@ -58,7 +59,8 @@ if __name__ == "__main__":
     S0 = np.array([generateComponent(n) for i in range(k)])
     p1 = partial(po.prox_unity_plus, axis=1)
     proxs_g=[[p1], None]
-    A, S, tr = nmf(Y, A0, S0, W=W, prox_A=p1, e_rel=1e-6, e_abs=1e-6/noise**2, traceback=True,accelerated=True)
+    tr = Traceback(2)
+    A, S = nmf(Y, A0, S0, W=W, prox_A=p1, e_rel=1e-6, e_abs=1e-6/noise**2, traceback=tr)
     # sort components to best match inputs
     A, S = match(A, S, trueS)
 

--- a/proxmin/algorithms.py
+++ b/proxmin/algorithms.py
@@ -103,6 +103,11 @@ def admm(X0, prox_f, step_f, prox_g=None, step_g=None, L=None, e_rel=1e-6, e_abs
         Moolekamp & Melchior, Algorithm 1 (arXiv:1708.09066)
     """
 
+    # no need for ADMM is prox_g is not set
+    # use accelerated APGM instead
+    if prox_g is None:
+        return pgm(X0, prox_f, step_f, accelerated=True, e_rel=e_rel, max_iter=max_iter, traceback=traceback)
+
     # use matrix adapter for convenient & fast notation
     _L = utils.MatrixAdapter(L)
     # get/check compatible step size for g

--- a/proxmin/algorithms.py
+++ b/proxmin/algorithms.py
@@ -532,7 +532,6 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, update=
     convergence, errors = [None] * N, [None] * N
     slack = [1.] * N
     it = 0
-    delta, l, Lmax = 0.999, 0, np.empty(N)
 
     if traceback:
         tr = utils.Traceback(N)
@@ -588,7 +587,6 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, update=
             break
 
         it += 1
-        l = Lmax.min()
 
     if it+1 >= max_iter:
         logger.warning("Solution did not converge")

--- a/proxmin/algorithms.py
+++ b/proxmin/algorithms.py
@@ -261,8 +261,7 @@ def sdmm(X0, prox_f, step_f, proxs_g=None, steps_g=None, Ls=None, e_rel=1e-6, e_
     if traceback:
         tr = utils.Traceback()
         tr.update_history(it, X=X, step_f=step_f, omega=omega)
-        tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
-                          S=[np.zeros(X.shape, dtype=X.dtype) for n in range(M)], steps_g=steps_g)
+        tr.update_history(it, M=M, Z=Z, U=U, R=U, S=[np.zeros(X.shape, dtype=X.dtype) for n in range(M)], steps_g=steps_g)
 
     while it < max_iter:
 
@@ -295,7 +294,7 @@ def sdmm(X0, prox_f, step_f, proxs_g=None, steps_g=None, Ls=None, e_rel=1e-6, e_
 
                 X,Z,U  = utils.initXZU(X0, _L)
                 tr.update_history(it, X=X, step_f=step_f)
-                tr.update_history(it, M=M, Z=Z, U=U, R=np.zeros(Z.shape, dtype=Z.dtype),
+                tr.update_history(it, M=M, Z=Z, U=U, R=U,
                                   S=[np.zeros(X.shape, dtype=X.dtype) for n in range(M)], steps_g=steps_g)
                 logger.info("Restarting with step_f = %.3f" % step_f)
 
@@ -445,14 +444,12 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, acceler
 
     # Initialization
     X, Z, U = [],[],[]
-    Xk = []
     LX, R, S = [None] * N, [None] * N, [None] * N
     for j in range(N):
         Xj, Zj, Uj = utils.initXZU(X0s[j], _L[j])
         X.append(Xj)
         Z.append(Zj)
         U.append(Uj)
-        Xk.append(Xj.copy())
 
     # containers
     convergence, errors = [None] * N, [None] * N
@@ -469,7 +466,7 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, acceler
                 _S = np.zeros(X[j].shape, dtype=X[j].dtype)
             tr.update_history(it, j=j, X=X[j], steps_f=steps_f[j])
             tr.update_history(it, j=j, M=M[j], steps_g=steps_g_[j], Z=Z[j], U=U[j],
-                              R=np.zeros(Z[j].shape, dtype=Z[j].dtype),
+                              R=U[j],
                               S=[np.zeros(X[j].shape, dtype=X[j].dtype) for n in range(M[j])])
             if accelerated:
                 tr.update_history(it, j=j, omega=proxs_f_acc[j].omega)
@@ -534,7 +531,6 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, acceler
             break
 
         it += 1
-        Xk = [X[j].copy() for j in range(N)]
         l = Lmax.min()
 
     if it+1 >= max_iter:

--- a/proxmin/algorithms.py
+++ b/proxmin/algorithms.py
@@ -449,26 +449,20 @@ def bsdmm(X0s, proxs_f, steps_f_cb, proxs_g=None, steps_g=None, Ls=None, update=
     """
 
     # use accelerated block-PGM if there's no proxs_g
-    if proxs_g is None or all([item is None for sublist in proxs_g for item in sublist]):
+    if proxs_g is None or not utils.hasNotNone(proxs_g):
         return bpgm(X0s, proxs_f, steps_f_cb, accelerated=True, update=update, update_order=update_order, max_iter=max_iter, e_rel=e_rel, traceback=traceback)
 
     # Set up
     N = len(X0s)
-
-    # allow proxs_g to be None
-    if proxs_g is None:
-        proxs_g = [proxs_g] * N
-    if(len(proxs_g) != N):
-        raise ValueError("len(proxs_g)={0} != N={1}".format(len(proxs_g), N))
+    assert len(proxs_g) == N
+    assert update.lower() in ['cascade', 'block']
+    assert steps_g_update.lower() in ['steps_f', 'fixed', 'relative']
 
     if np.isscalar(e_rel):
         e_rel = [e_rel] * N
     if np.isscalar(e_abs):
         e_abs = [e_abs] * N
     steps_f = [None] * N
-
-    assert update.lower() in ['cascade', 'block']
-    assert steps_g_update.lower() in ['steps_f', 'fixed', 'relative']
 
     if update_order is None:
         update_order = range(N)

--- a/proxmin/nmf.py
+++ b/proxmin/nmf.py
@@ -102,7 +102,7 @@ def normalizeMatrix(M, axis):
         norm = np.broadcast_to(norm, M.shape)
     return norm
 
-def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plus, proxs_g=None, steps_g=None, Ls=None, slack=0.9, update_order=None, steps_g_update='steps_f', accelerated=False, max_iter=1000, e_rel=1e-3, e_abs=0, traceback=False):
+def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plus, proxs_g=None, steps_g=None, Ls=None, slack=0.9, update_order=None, steps_g_update='steps_f', max_iter=1000, e_rel=1e-3, e_abs=0, traceback=None):
     """Non-negative matrix factorization.
 
     This method solves the NMF problem
@@ -126,15 +126,13 @@ def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plu
             See Steps_AS() for details.
         update_order: list of factor indices in update order
             j=0 -> A, j=1 -> S
-        accelerated: If Nesterov acceleration should be used for A and S
         max_iter: maximum iteration number, irrespective of current residuals
         e_rel: relative error threshold for primal and dual residuals
         e_abs: absolute error threshold for primal and dual residuals
-        traceback: whether a record of all optimization variables is kept
+        traceback: utils.Traceback to hold variable histories
 
     Returns:
         A, S: updated amplitude and source matrices
-        A, S, trace: adds utils.Traceback if traceback is True
 
     See also:
         algorithms.bsdmm for update_order and steps_g_update
@@ -159,11 +157,5 @@ def nmf(Y, A0, S0, W=None, prox_A=operators.prox_plus, prox_S=operators.prox_plu
     f = partial(prox_likelihood, Y=Y, WA=WA, WS=WS, prox_S=prox_S, prox_A=prox_A)
 
     Xs = [A0, S0]
-    res = algorithms.bsdmm(Xs, f, steps_f, proxs_g, steps_g=steps_g, Ls=Ls,
-                           update_order=update_order, steps_g_update=steps_g_update, accelerated=accelerated,
-                           max_iter=max_iter, e_rel=e_rel, e_abs=e_abs, traceback=traceback)
-
-    if not traceback:
-        return res[0], res[1]
-    else:
-        return res[0][0], res[0][1], res[1]
+    return algorithms.bsdmm(Xs, f, steps_f, proxs_g, steps_g=steps_g, Ls=Ls,
+                           update_order=update_order, steps_g_update=steps_g_update, max_iter=max_iter, e_rel=e_rel, e_abs=e_abs, traceback=traceback)

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -236,30 +236,21 @@ class ApproximateCache(object):
             self.it += 1
         return self.stored
 
-class ProxWithMemory(object):
-    # Prox that keeps memory of last call argument
-    # optionally: Nesterov acceleration
-    def __init__(self, prox_f, accelerated=False):
-        self.prox_f = prox_f
-        self.accelerated = accelerated
+class NesterovStepper(object):
+    def __init__(self, accelerated=False):
         self.t = 1.
-        self.omega = 0.
-        self.X_ = None
+        self.accelerated = accelerated
 
-    def __call__(self, X, step):
-        if self.omega > 0 and self.X_ is not None:
-            _X = X + self.omega*(X - self.X_)
-        else:
-            _X = X
-
+    @property
+    def omega(self):
         if self.accelerated:
             t_ = 0.5*(1 + np.sqrt(4*self.t*self.t + 1))
-            self.omega = (self.t - 1)/t_
+            om = (self.t - 1)/t_
             self.t = t_
-
-        self.X_ = X.copy()
-
-        return self.prox_f(_X, step)
+            print ("omega = %.3f" % om)
+            return om
+        else:
+            return 0
 
 def initXZU(X0, L):
     X = X0.copy()

--- a/proxmin/utils.py
+++ b/proxmin/utils.py
@@ -247,7 +247,6 @@ class NesterovStepper(object):
             t_ = 0.5*(1 + np.sqrt(4*self.t*self.t + 1))
             om = (self.t - 1)/t_
             self.t = t_
-            print ("omega = %.3f" % om)
             return om
         else:
             return 0
@@ -398,3 +397,14 @@ def check_convergence(newX, oldX, e_rel):
     norms = [np.sum(new_old), np.sum(old2)]
     convergent = norms[0] >= (1-e_rel**2)*norms[1]
     return convergent, norms
+
+def hasNotNone(l):
+    i = 0
+    for ll in l:
+        if ll is not None:
+            if hasattr(ll, '__iter__'):
+                for lll in ll:
+                    if lll is not None:
+                        return len(l) - i
+        i += 1
+    return 0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description_content_type='text/markdown',
     packages = packages,
     include_package_data=False,
-    version = '0.4.4',
+    version = '0.5.0',
     license='MIT',
     author = 'Peter Melchior, Fred Moolekamp',
     author_email = 'peter.m.melchior@gmail.com',


### PR DESCRIPTION
Implements the Block version of PGM.

ADMM now uses PGM as fall-back option if prox_g is not set; bSDMM uses bPGM in the same situation with multiple variables. The advantage is a much lighter algorithm without the LX, Z, U, R, and S variables.