### PR TITLE
Add tag-based versioning for git archive support

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/proxmin/nmf.py
+++ b/proxmin/nmf.py
@@ -61,7 +61,7 @@ def step_pgm(*X, it=None, W=1):
         step_A, step_S
     """
     A, S = X
-    if W is 1:
+    if W == 1:
         return step_A(A, S), step_S(A, S)
     else:
         C, K = A.shape

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 import os
-
-packages = []
-for root, dirs, files in os.walk('.'):
-    if not root.startswith('./build') and '__init__.py' in files:
-        packages.append(root[2:])
 
 long_description = open('README.md').read()
 
@@ -13,9 +8,9 @@ setup(
     description = 'Proximal methods for constrained optimization',
     long_description = long_description,
     long_description_content_type='text/markdown',
-    packages = packages,
+    packages=find_packages(),
     include_package_data=False,
-    version = '0.6.9',
+    use_scm_version=True,
     license='MIT',
     author = 'Peter Melchior, Fred Moolekamp',
     author_email = 'peter.m.melchior@gmail.com',
@@ -30,5 +25,6 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis"
     ],
     keywords = ['optimization', 'constrained optimization', 'proximal algorithms', 'data analysis', 'non-negative matrix factorization'],
-    requires=['numpy','scipy']
+    setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
+    install_requires=['numpy','scipy'],
 )


### PR DESCRIPTION
This commit lets you use git tags to create new versions and makes it unnecessary to update setup.py when creating a new version.

This will let you get a tarball directly from github with enough information to install a proxmin version.

This will help with creating a standard conda-forge recipe, which I'd like to do.

As an example of what this PR can enable, try this script to install a fake 0.6.10 version, as tagged in my fork. (Note that the tag is currently in my fork - not in this repo)

```bash
export GITHUB_ORG="brianv0"
export TAG="0.6.10"
export PROXMINDIR=$(mktemp -d)
cd $PROXMINDIR
curl -LO https://github.com/${GITHUB_ORG}/proxmin/archive/$TAG.tar.gz
tar xzf $TAG.tar.gz
cd proxmin-$TAG
pip3 install .
```

This PR also contains a fix for python 3.8 syntax warning.