### PR TITLE
Python 3.8 bugfix

### DIFF
--- a/proxmin/nmf.py
+++ b/proxmin/nmf.py
@@ -61,7 +61,7 @@ def step_pgm(*X, it=None, W=1):
         step_A, step_S
     """
     A, S = X
-    if W is 1:
+    if W == 1:
         return step_A(A, S), step_S(A, S)
     else:
         C, K = A.shape


### PR DESCRIPTION
In python 3.8 using `is` to compare a variable to a number is deprecated, instead we need to use `==`. So this PR fixes the bug and prevents the warning from being displayed.